### PR TITLE
fix error on destruction of unchecked components

### DIFF
--- a/src/app/modules/directives/svg-circle.directive.ts
+++ b/src/app/modules/directives/svg-circle.directive.ts
@@ -20,7 +20,7 @@ export class SvgCircleDirective implements AfterViewChecked, OnChanges, OnDestro
   /**
    * Globally used variables within the directive.
    */
-  private _circle: Circle;
+  private _circle?: Circle;
 
   /**
    * Import variables for the circle directive.
@@ -65,7 +65,7 @@ export class SvgCircleDirective implements AfterViewChecked, OnChanges, OnDestro
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._circle.remove();
+    this._circle?.remove();
   }
 
   /**

--- a/src/app/modules/directives/svg-ellipse.directive.ts
+++ b/src/app/modules/directives/svg-ellipse.directive.ts
@@ -20,7 +20,7 @@ export class SvgEllipseDirective implements AfterViewChecked, OnChanges, OnDestr
   /**
    * Globally used variables within the directive.
    */
-  private _ellipse: Ellipse;
+  private _ellipse?: Ellipse;
 
   /**
    * Import variables for the ellipse directive.
@@ -64,7 +64,7 @@ export class SvgEllipseDirective implements AfterViewChecked, OnChanges, OnDestr
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._ellipse.remove();
+    this._ellipse?.remove();
   }
 
   /**

--- a/src/app/modules/directives/svg-image.directive.ts
+++ b/src/app/modules/directives/svg-image.directive.ts
@@ -20,7 +20,7 @@ export class SvgImageDirective implements AfterViewChecked, OnDestroy, OnChanges
   /**
    * Globally used variables within the directive.
    */
-  private _image: Image;
+  private _image?: Image;
 
   /**
    * Import variables for the image directive.
@@ -65,7 +65,7 @@ export class SvgImageDirective implements AfterViewChecked, OnDestroy, OnChanges
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._image.remove();
+    this._image?.remove();
   }
 
   /**

--- a/src/app/modules/directives/svg-line.directive.ts
+++ b/src/app/modules/directives/svg-line.directive.ts
@@ -20,7 +20,7 @@ export class SvgLineDirective implements AfterViewChecked, OnChanges, OnDestroy 
   /**
    * Globally used variables within the directive.
    */
-  private _line: Line;
+  private _line?: Line;
 
   /**
    * Import variables for the line directive.
@@ -65,7 +65,7 @@ export class SvgLineDirective implements AfterViewChecked, OnChanges, OnDestroy 
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._line.remove();
+    this._line?.remove();
   }
 
   /**

--- a/src/app/modules/directives/svg-path.directive.ts
+++ b/src/app/modules/directives/svg-path.directive.ts
@@ -20,7 +20,7 @@ export class SvgPathDirective implements AfterViewChecked, OnChanges, OnDestroy 
   /**
    * Globally used variables within the directive.
    */
-  private _path: Path;
+  private _path?: Path;
 
   /**
    * Import variables for the path directive.
@@ -66,7 +66,7 @@ export class SvgPathDirective implements AfterViewChecked, OnChanges, OnDestroy 
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._path.remove();
+    this._path?.remove();
   }
 
   /**

--- a/src/app/modules/directives/svg-polygon.directive.ts
+++ b/src/app/modules/directives/svg-polygon.directive.ts
@@ -20,7 +20,7 @@ export class SvgPolygonDirective implements AfterViewChecked, OnChanges, OnDestr
   /**
    * Globally used variables within the directive.
    */
-  private _polygon: Polygon;
+  private _polygon?: Polygon;
 
   /**
    * Import variables for the polygon directive.
@@ -64,7 +64,7 @@ export class SvgPolygonDirective implements AfterViewChecked, OnChanges, OnDestr
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._polygon.remove();
+    this._polygon?.remove();
   }
 
   /**
@@ -121,7 +121,7 @@ export class SvgPolygonDirective implements AfterViewChecked, OnChanges, OnDestr
       .on('mouseout', (evt: MouseEvent) => this.mouseOutEvent.emit(evt)); // Assign mouse out event
 
     // Let's set element in a correct position
-    this.setCorrectPosition();  
+    this.setCorrectPosition();
 
     // Add classes to the polygon
     this.addRemoveClasses(this.classes);

--- a/src/app/modules/directives/svg-polyline.directive.ts
+++ b/src/app/modules/directives/svg-polyline.directive.ts
@@ -20,7 +20,7 @@ export class SvgPolylineDirective implements AfterViewChecked, OnChanges, OnDest
   /**
    * Globally used variables within the directive.
    */
-  private _polyline: Polyline;
+  private _polyline?: Polyline;
 
   /**
    * Input variables for the polyline directive.
@@ -64,7 +64,7 @@ export class SvgPolylineDirective implements AfterViewChecked, OnChanges, OnDest
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._polyline.remove();
+    this._polyline?.remove();
   }
 
   /**

--- a/src/app/modules/directives/svg-rect.directive.ts
+++ b/src/app/modules/directives/svg-rect.directive.ts
@@ -20,7 +20,7 @@ export class SvgRectDirective implements AfterViewChecked, OnChanges, OnDestroy 
   /**
    * Globally used variables within the directive.
    */
-  private _rect: Rect;
+  private _rect?: Rect;
 
   /**
    * Import variables for the rectangular directive.
@@ -67,7 +67,7 @@ export class SvgRectDirective implements AfterViewChecked, OnChanges, OnDestroy 
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._rect.remove();
+    this._rect?.remove();
   }
 
   /**

--- a/src/app/modules/directives/svg-text.directive.ts
+++ b/src/app/modules/directives/svg-text.directive.ts
@@ -20,7 +20,7 @@ export class SvgTextDirective implements AfterViewChecked, OnChanges, OnDestroy 
   /**
    * Globally used variables within the directive.
    */
-  private _text: Text;
+  private _text?: Text;
 
   /**
    * Import variables for the text directive.
@@ -65,7 +65,7 @@ export class SvgTextDirective implements AfterViewChecked, OnChanges, OnDestroy 
    * Does all required pre-requisites before destroying the component.
    */
   ngOnDestroy(): void {
-    this._text.remove();
+    this._text?.remove();
   }
 
   /**


### PR DESCRIPTION
Thanks for the cool library! 

I noticed that in some cases when components get added and quickly removed from a template, an error is produced:

```
TypeError: Cannot read property 'remove' of undefined
    at SvgCircleDirective.ngOnDestroy (http://localhost:9876/_karma_webpack_/webpack:/node_modules/ngx-svg/__ivy_ngcc__/fesm2015/ngx-svg.js:522:1)
    at executeOnDestroys (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/__ivy_ngcc__/fesm2015/core.js:7352:1)
    at cleanUpView (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/__ivy_ngcc__/fesm2015/core.js:7265:1)
    at destroyViewTree (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/__ivy_ngcc__/fesm2015/core.js:7091:1)
    at destroyLView (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/__ivy_ngcc__/fesm2015/core.js:7243:1)
    at ViewContainerRef.remove (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/__ivy_ngcc__/fesm2015/core.js:23184:1)
    at http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/common/__ivy_ngcc__/fesm2015/common.js:3273:1
    at DefaultIterableDiffer.forEachOperation (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/__ivy_ngcc__/fesm2015/core.js:21495:1)
    at NgForOf._applyChanges (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/common/__ivy_ngcc__/fesm2015/common.js:3263:1)
    at NgForOf.ngDoCheck (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/common/__ivy_ngcc__/fesm2015/common.js:3258:1)
```

The error appears to happen because the underlying private members are only created after a view is checked for changes, so they can be undefined in a destroy handler.

To fix the error, I check that each class-specific private instance exists before calling `remove`. It wasn't apparent how to reproduce the error in your tests, so I haven't added any new assertions or tests.